### PR TITLE
fix: persist PlexServerURL to config during --install

### DIFF
--- a/plexargod.sh
+++ b/plexargod.sh
@@ -34,6 +34,15 @@ RestartSec=5s
 [Install]
 WantedBy=multi-user.target
 UNIT
+        mkdir -p /etc/plexargod
+        if [ ! -f /etc/plexargod/plexargod.conf ]; then
+            echo "# /etc/plexargod/plexargod.conf" > /etc/plexargod/plexargod.conf
+        fi
+        if grep -q "^PlexServerURL=" /etc/plexargod/plexargod.conf 2>/dev/null; then
+            sed -i "s|^PlexServerURL=.*|PlexServerURL=${PLEX_URL}|" /etc/plexargod/plexargod.conf
+        else
+            echo "PlexServerURL=${PLEX_URL}" >> /etc/plexargod/plexargod.conf
+        fi
         systemctl daemon-reload
         systemctl enable plexargod
         echo "plexargod.service installed and enabled."

--- a/plexargod.sh
+++ b/plexargod.sh
@@ -3,6 +3,46 @@
 plexargodVersion='0.1.0'
 INTERACTIVE=false
 [ -t 0 ] && INTERACTIVE=true
+[ -z "${plexargod_path}" ] && plexargod_path="/etc/plexargod"
+[ -z "${plexargod_conf}" ] && plexargod_conf="${plexargod_path}/plexargod.conf"
+
+conf_init() {
+    mkdir -p "${plexargod_path}"
+    if [ ! -f "${plexargod_conf}" ]; then
+        printf '# %s\n' "${plexargod_conf}" > "${plexargod_conf}"
+    fi
+}
+
+# Config values are sourced by bash, so they must be written as shell-safe literals.
+conf_set() {
+    local key="$1"
+    local value="$2"
+    local quoted_value
+    local new_line
+    local tmp_conf
+    local updated=false
+
+    printf -v quoted_value '%q' "${value}"
+    new_line="${key}=${quoted_value}"
+    conf_init
+
+    if grep -q "^${key}=" "${plexargod_conf}" 2>/dev/null; then
+        tmp_conf=$(mktemp)
+        while IFS= read -r line || [ -n "${line}" ]; do
+            if [[ "${line}" == "${key}="* ]]; then
+                if ! ${updated}; then
+                    printf '%s\n' "${new_line}"
+                    updated=true
+                fi
+            else
+                printf '%s\n' "${line}"
+            fi
+        done < "${plexargod_conf}" > "${tmp_conf}"
+        mv "${tmp_conf}" "${plexargod_conf}"
+    else
+        printf '%s\n' "${new_line}" >> "${plexargod_conf}"
+    fi
+}
 
 case "$1" in
     --interactive) INTERACTIVE=true ;;
@@ -34,15 +74,7 @@ RestartSec=5s
 [Install]
 WantedBy=multi-user.target
 UNIT
-        mkdir -p /etc/plexargod
-        if [ ! -f /etc/plexargod/plexargod.conf ]; then
-            echo "# /etc/plexargod/plexargod.conf" > /etc/plexargod/plexargod.conf
-        fi
-        if grep -q "^PlexServerURL=" /etc/plexargod/plexargod.conf 2>/dev/null; then
-            sed -i "s|^PlexServerURL=.*|PlexServerURL='${PLEX_URL}'|" /etc/plexargod/plexargod.conf
-        else
-            echo "PlexServerURL='${PLEX_URL}'" >> /etc/plexargod/plexargod.conf
-        fi
+        conf_set PlexServerURL "${PLEX_URL}"
         systemctl daemon-reload
         systemctl enable plexargod
         echo "plexargod.service installed and enabled."
@@ -68,18 +100,6 @@ fi
 
 ### Variable Setup
 
-# Write a key=value pair to the config file (update if exists, append if not)
-conf_set() {
-    if grep -q "^$1=" "${plexargod_conf}" 2>/dev/null; then
-        sed -i "s|^$1=.*|$1=$2|" "${plexargod_conf}"
-    else
-        echo "$1=$2" >> "${plexargod_conf}"
-    fi
-}
-
-[ -z "${plexargod_path}" ] && plexargod_path="/etc/plexargod"
-[ -z "${plexargod_conf}" ] && plexargod_conf="${plexargod_path}/plexargod.conf"
-
 # give a warning if cloudflared cant open its port to Plex, it probably means that Plex isnt running or is unreachable
 ArgoOriginDown=$(journalctl -t cloudflared -n20 | grep -oP 'msg="unable to connect to the origin[^}]+')
 if [ "${ArgoOriginDown}" ]; then
@@ -102,7 +122,7 @@ if [ -f "${plexargod_conf}" ]; then
     source "${plexargod_conf}"
     echo "Sourced ${plexargod_conf}"
 else
-    echo "# ${plexargod_conf}" > "${plexargod_conf}"
+    conf_init
 fi
 
 # if VARIABLE is empty/malformed, use defaults

--- a/plexargod.sh
+++ b/plexargod.sh
@@ -39,9 +39,9 @@ UNIT
             echo "# /etc/plexargod/plexargod.conf" > /etc/plexargod/plexargod.conf
         fi
         if grep -q "^PlexServerURL=" /etc/plexargod/plexargod.conf 2>/dev/null; then
-            sed -i "s|^PlexServerURL=.*|PlexServerURL=${PLEX_URL}|" /etc/plexargod/plexargod.conf
+            sed -i "s|^PlexServerURL=.*|PlexServerURL='${PLEX_URL}'|" /etc/plexargod/plexargod.conf
         else
-            echo "PlexServerURL=${PLEX_URL}" >> /etc/plexargod/plexargod.conf
+            echo "PlexServerURL='${PLEX_URL}'" >> /etc/plexargod/plexargod.conf
         fi
         systemctl daemon-reload
         systemctl enable plexargod


### PR DESCRIPTION
## Summary
- The `PLEX_URL` argument passed to `--install` was only written into the systemd service file (`ExecStart` for cloudflared) but never persisted to `plexargod.conf`
- On new installations, `PlexServerURL` would always fall back to `http://localhost:32400` regardless of what URL was passed during install
- Now creates the config directory and writes `PlexServerURL` to `plexargod.conf` during `--install`

Closes #27

## Test plan
- [ ] Run `plexargod --install http://custom-host:32400` and verify `PlexServerURL=http://custom-host:32400` appears in `/etc/plexargod/plexargod.conf`
- [ ] Run `plexargod --install` (no URL) and verify `PlexServerURL=http://localhost:32400` is written to conf
- [ ] Run `--install` again with a different URL and verify the existing `PlexServerURL` is updated (not duplicated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)